### PR TITLE
Using environment values for actinia templates

### DIFF
--- a/actinia_module_plugin/core/modules/actinia_common.py
+++ b/actinia_module_plugin/core/modules/actinia_common.py
@@ -47,7 +47,8 @@ from actinia_module_plugin.model.modules import Module
 
 
 ENV = {
-    key.replace("TEMPLATE_VALUE_", ""): val for key, val in env.items()
+    key.replace("TEMPLATE_VALUE_", ""): val
+    for key, val in env.items()
     if key.startswith("TEMPLATE_VALUE_")
 }
 
@@ -406,9 +407,9 @@ def setEnvParamToOptional(params):
         for param in params:
             if param["name"].upper() in ENV:
                 param["optional"] = True
-                param["description"] += (
-                    "; Default value exist for this installation."
-                )
+                param[
+                    "description"
+                ] += "; Default value exist for this installation."
 
 
 def createActiniaModule(resourceBaseSelf, processchain):

--- a/actinia_module_plugin/core/modules/actinia_common.py
+++ b/actinia_module_plugin/core/modules/actinia_common.py
@@ -21,8 +21,8 @@ Common module for file based and redis templates
 """
 
 __license__ = "Apache-2.0"
-__author__ = "Carmen Tawalika"
-__copyright__ = "Copyright 2019, mundialis"
+__author__ = "Carmen Tawalika, Anika Weinmann"
+__copyright__ = "Copyright 2019-2023, mundialis"
 __maintainer__ = "Carmen Tawalika"
 
 
@@ -402,11 +402,13 @@ def setEnvParamToOptional(params):
     True and add a comment to the parameter 'description' is the parameter is
     set via the environment variables.
     """
-    # TODO change description
     if len(ENV) > 0:
         for param in params:
             if param["name"].upper() in ENV:
                 param["optional"] = True
+                param["description"] += (
+                    "; Default value exist for this installation."
+                )
 
 
 def createActiniaModule(resourceBaseSelf, processchain):

--- a/actinia_module_plugin/core/modules/actinia_common.py
+++ b/actinia_module_plugin/core/modules/actinia_common.py
@@ -397,7 +397,7 @@ class PlaceholderTransformer(object):
             self.vm_params.append(exe_param)
 
 
-def setEnvParamToOptional(params):
+def set_env_param_to_optional(params):
     """
     This function changes in a list with parameters the 'optional' value to
     True and add a comment to the parameter 'description' is the parameter is
@@ -478,8 +478,8 @@ def createActiniaModule(resourceBaseSelf, processchain):
 
     # set optinal to True if parameter or returns is set as environment
     # variable
-    setEnvParamToOptional(pt.vm_params)
-    setEnvParamToOptional(pt.vm_returns)
+    set_env_param_to_optional(pt.vm_params)
+    set_env_param_to_optional(pt.vm_returns)
 
     categories = ["actinia-module"]
     if user_template:

--- a/actinia_module_plugin/core/modules/actinia_common.py
+++ b/actinia_module_plugin/core/modules/actinia_common.py
@@ -28,6 +28,7 @@ __maintainer__ = "Carmen Tawalika"
 
 import json
 import re
+from os import environ as env
 
 # from actinia_module_plugin.core.common import filter_func
 from actinia_module_plugin.core.modules.actinia_global_templates import (
@@ -43,6 +44,12 @@ from actinia_module_plugin.core.common import (
 from actinia_module_plugin.core.modules.processor import run_process_chain
 from actinia_module_plugin.core.modules.parser import ParseInterfaceDescription
 from actinia_module_plugin.model.modules import Module
+
+
+ENV = {
+    key.replace("TEMPLATE_VALUE_", ""): val for key, val in env.items()
+    if key.startswith("TEMPLATE_VALUE_")
+}
 
 
 def render_template(pc):
@@ -389,6 +396,19 @@ class PlaceholderTransformer(object):
             self.vm_params.append(exe_param)
 
 
+def setEnvParamToOptional(params):
+    """
+    This function changes in a list with parameters the 'optional' value to
+    True and add a comment to the parameter 'description' is the parameter is
+    set via the environment variables.
+    """
+    # TODO change description
+    if len(ENV) > 0:
+        for param in params:
+            if param["name"].upper() in ENV:
+                param["optional"] = True
+
+
 def createActiniaModule(resourceBaseSelf, processchain):
     """
     This method is used to create self-descriptions for actinia-modules.
@@ -452,6 +472,11 @@ def createActiniaModule(resourceBaseSelf, processchain):
                                 temp_dict[key] = i[key]
                             temp_dict["name"] = undefitem
                             pt.vm_returns.append(temp_dict)
+
+    # set optinal to True if parameter or returns is set as environment
+    # variable
+    setEnvParamToOptional(pt.vm_params)
+    setEnvParamToOptional(pt.vm_returns)
 
     categories = ["actinia-module"]
     if user_template:

--- a/actinia_module_plugin/core/modules/parser.py
+++ b/actinia_module_plugin/core/modules/parser.py
@@ -242,9 +242,8 @@ def ParseInterfaceDescription(xml_string, keys=None):
         gm_dict["parameter"] = []
     elif (
         type(xmltodict.parse(xml_string)["task"]["parameter"])
-        == collections.OrderedDict or
-        type(xmltodict.parse(xml_string)["task"]["parameter"])
-        == dict
+        == collections.OrderedDict
+        or type(xmltodict.parse(xml_string)["task"]["parameter"]) == dict
     ):
         gm_dict["parameter"] = [gm_dict["parameter"]]
     else:

--- a/actinia_module_plugin/core/modules/parser.py
+++ b/actinia_module_plugin/core/modules/parser.py
@@ -242,7 +242,9 @@ def ParseInterfaceDescription(xml_string, keys=None):
         gm_dict["parameter"] = []
     elif (
         type(xmltodict.parse(xml_string)["task"]["parameter"])
-        == collections.OrderedDict
+        == collections.OrderedDict or
+        type(xmltodict.parse(xml_string)["task"]["parameter"])
+        == dict
     ):
         gm_dict["parameter"] = [gm_dict["parameter"]]
     else:

--- a/actinia_module_plugin/core/processing.py
+++ b/actinia_module_plugin/core/processing.py
@@ -36,6 +36,7 @@ from actinia_module_plugin.core.common import (
     get_global_template_source,
     get_template_undef,
 )
+from actinia_module_plugin.core.modules.actinia_common import ENV
 from actinia_module_plugin.resources.logging import log
 from actinia_module_plugin.resources.templating import pcTplEnv
 
@@ -144,6 +145,16 @@ def check_for_errors(undef, parsed_content, tpl_source, kwargs):
     return None
 
 
+def fill_env_values(filled_params, undef):
+    """This function checks if a undefined variable is set in the environment
+    variables and set it in kwargs if not already set.
+    """
+    if len(ENV) > 0:
+        for param in undef:
+            if param not in filled_params and param.upper() in ENV:
+                filled_params[param] = ENV[param.upper()]
+
+
 def fillTemplateFromProcessChain(module):
     """This method receives a process chain for an actinia module and loads
     the according process chain template from redis or filesystem. The
@@ -166,6 +177,8 @@ def fillTemplateFromProcessChain(module):
 
     undef = get_template_undef(tpl_source)
     parsed_content = pcTplEnv.parse(tpl_source)
+
+    fill_env_values(kwargs, undef)
 
     errors = check_for_errors(undef, parsed_content, tpl_source, kwargs)
     if errors is not None:

--- a/config/templates/pc_templates/use_env_value.json
+++ b/config/templates/pc_templates/use_env_value.json
@@ -9,7 +9,7 @@
             "inputs": [
               {
                 "param": "map",
-                "value": "{{ raster }}"
+                "value": "{{ env_raster }}"
               }
             ]
           }

--- a/config/templates/pc_templates/use_env_value.json
+++ b/config/templates/pc_templates/use_env_value.json
@@ -1,0 +1,19 @@
+{
+    "id": "use_env_value",
+    "description": "r.info set flags per env var.",
+    "template": {
+        "list": [
+          {
+            "module": "r.info",
+            "id": "r.info_test",
+            "inputs": [
+              {
+                "param": "map",
+                "value": "{{ raster }}"
+              }
+            ]
+          }
+        ],
+        "version": "1"
+    }
+}

--- a/config/templates/pc_templates/use_env_value2.json
+++ b/config/templates/pc_templates/use_env_value2.json
@@ -1,0 +1,19 @@
+{
+    "id": "use_env_value2",
+    "description": "r.info set flags per env var.",
+    "template": {
+        "list": [
+          {
+            "module": "g.list",
+            "id": "g.list_test",
+            "inputs": [
+              {
+                "param": "type",
+                "value": "{{ env_type }}"
+              }
+            ]
+          }
+        ],
+        "version": "1"
+    }
+}

--- a/docker/actinia-module-plugin-test/Dockerfile
+++ b/docker/actinia-module-plugin-test/Dockerfile
@@ -39,4 +39,4 @@ WORKDIR /src/actinia-module-plugin/
 RUN chmod a+x tests_with_redis.sh
 RUN python3 setup.py install
 
-# RUN ./tests_with_redis.sh
+RUN ./tests_with_redis.sh

--- a/docker/actinia-module-plugin-test/Dockerfile
+++ b/docker/actinia-module-plugin-test/Dockerfile
@@ -7,6 +7,8 @@ ENV ACTINIA_CUSTOM_TEST_CFG /etc/default/actinia-module-plugin-test
 
 # TODO do not set DEFAULT_CONFIG_PATH if this is fixed
 ENV DEFAULT_CONFIG_PATH /etc/default/actinia-module-plugin-test
+# set TEMPLATE_VALUE_ for testing
+ENV TEMPLATE_VALUE_ENV_RASTER elevation
 
 # install things only for tests
 RUN apk add redis
@@ -30,9 +32,10 @@ COPY docker/actinia-module-plugin-test/actinia-module-plugin-test.cfg /etc/defau
 COPY docker/actinia-module-plugin-test/actinia-module-plugin-test.cfg /etc/default/actinia-module-plugin-test
 COPY . /src/actinia-module-plugin/
 
+
 WORKDIR /src/actinia-module-plugin/
 
 RUN chmod a+x tests_with_redis.sh
 RUN python3 setup.py install
 
-RUN ./tests_with_redis.sh
+# RUN ./tests_with_redis.sh

--- a/docker/actinia-module-plugin-test/Dockerfile
+++ b/docker/actinia-module-plugin-test/Dockerfile
@@ -9,6 +9,7 @@ ENV ACTINIA_CUSTOM_TEST_CFG /etc/default/actinia-module-plugin-test
 ENV DEFAULT_CONFIG_PATH /etc/default/actinia-module-plugin-test
 # set TEMPLATE_VALUE_ for testing
 ENV TEMPLATE_VALUE_ENV_RASTER elevation
+ENV TEMPLATE_VALUE_ENV_TYPE raster
 
 # install things only for tests
 RUN apk add redis

--- a/tests/resources/processing/env_var.json
+++ b/tests/resources/processing/env_var.json
@@ -1,0 +1,10 @@
+{
+	"version": "1",
+	"description": "Test for environment variables",
+	"list": [
+		{
+			"module": "use_env_value2",
+			"id": "env_value_test"
+		}
+	]
+}

--- a/tests/resources/processing/env_var_overwrite.json
+++ b/tests/resources/processing/env_var_overwrite.json
@@ -1,0 +1,16 @@
+{
+	"version": "1",
+	"description": "Test overwriting of environment variables",
+	"list": [
+		{
+			"module": "use_env_value2",
+			"id": "overwrite_env_value_test)",
+			"inputs": [
+				{
+					"param": "env_type",
+					"value": "vector"
+				}
+			]
+		}
+	]
+}

--- a/tests/test_env_values.py
+++ b/tests/test_env_values.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2023 mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+Test the usage of environment variables
+"""
+
+__license__ = "Apache-2.0"
+__author__ = "Anika Weinmann"
+__copyright__ = "Copyright 2023, mundialis"
+
+
+from flask import Response
+
+from actinia_api import URL_PREFIX
+
+from testsuite import (
+    ActiniaTestCase,
+)
+
+global allTemplatesCount
+global templateUUID
+
+
+class ActiniaTestEnvValues(ActiniaTestCase):
+    def test_env_values(self):
+        """Test Usage of environment values inside a template"""
+
+        respStatusCode = 200
+        msg = "Default value exist for this installation."
+
+        resp = self.app.get(
+            URL_PREFIX + "/actinia_modules/use_env_value",
+            headers=self.user_auth_header,
+        )
+        assert isinstance(resp, Response)
+        assert resp.status_code == respStatusCode
+        params = {
+            p["name"]: [p["optional"], p["description"]]
+            for p in resp.json["parameters"]
+        }
+        assert "env_raster" in params
+        assert params["env_raster"][0] is True
+        assert msg in params["env_raster"][1]

--- a/tests/test_processing_global.py
+++ b/tests/test_processing_global.py
@@ -166,7 +166,7 @@ class ActiniaProcessingTest(ActiniaTestCase):
                 resp.json["urls"]["status"], headers=self.user_auth_header
             )
             status = resp.json["status"]
-            print(status)
+
         # check if parameter is set
         resp.json["process_chain_list"]
         params = [


### PR DESCRIPTION
Environment values should be able to be used inside actinia templates

- the environment depending values will be set via environment variables with the prefix `TEMPLATE_VALUE_`, then the plugin will use these values to set the values for the actinia module; e.g.
  - env variable: `TEMPLATE_VALUE_DB_CONNECTION`
  - and in the actinia module template `{{ db_connection }}`
  - the default env variable value can be overwritten by setting `db_connection` in the process chain of the actinia module
- by requesting an actinia module the plugin has to check if the parameter is set as environment variable. If yes:  
  - change `optional=True`
  - add to `description` "default value exist for this installation"

Additional, fixing for GRASS GIS modules with only one parameter.