### PR TITLE
Add 404 on TemplateNotFound error

### DIFF
--- a/src/actinia_module_plugin/api/modules/actinia_process.py
+++ b/src/actinia_module_plugin/api/modules/actinia_process.py
@@ -19,6 +19,7 @@ __maintainer__ = "Carmen Tawalika"
 
 
 from flask import jsonify, make_response
+from jinja2.exceptions import TemplateNotFound
 import pickle
 
 from actinia_core.core.common.kvdb_interface import enqueue_job
@@ -91,7 +92,18 @@ class ProcessActiniaModule(ResourceBase):
         # TODO: Currently no project can be read out of request body.
         # Instead it will take the first project listed in actinia module
         # To be sure only write a single project inside template.
-        virtual_module = createActiniaModule(self, actiniamodule)
+        try:
+            virtual_module = createActiniaModule(self, actiniamodule)
+        except TemplateNotFound:
+            return make_response(
+                jsonify(
+                    {
+                        "code": 404,
+                        "message": f"Module '{actiniamodule}' not found.",
+                    }
+                ),
+                404,
+            )
         preprocess_kwargs["project_name"] = virtual_module["projects"][0]
 
         start_job = start_job_ephemeral_processing_with_export


### PR DESCRIPTION
When a module is not found, return 404 for module processing endpoint:

```bash
curl -i -X POST -H 'Content-Type: application/json' -H 'accept: application/json'     -u actinia-gdi:actinia-gdi     -d @$JSON http://127.0.0.1:8088/api/v3/actinia_modules/invalid_module/process
HTTP/1.1 404 NOT FOUND
Server: Werkzeug/3.1.5 Python/3.12.12
Date: Thu, 29 Jan 2026 14:16:35 GMT
Content-Type: application/json
Content-Length: 69
Access-Control-Allow-Origin: *
Connection: close

{
  "code": 404,
  "message": "Module 'invalid_module' not found."
}
```