### PR TITLE
Add version to module self-description

### DIFF
--- a/src/actinia_module_plugin/core/modules/actinia_common.py
+++ b/src/actinia_module_plugin/core/modules/actinia_common.py
@@ -600,6 +600,7 @@ def createActiniaModule(
         projects=projects,
         parameters=pt.vm_params + pt.vm_returns,
         returns=exported_results,
+        version=pc_template["template"].get("version", "undefined"),
     )
 
     return virtual_module

--- a/src/actinia_module_plugin/core/modules/parser.py
+++ b/src/actinia_module_plugin/core/modules/parser.py
@@ -18,6 +18,8 @@ import collections
 import json
 import xmltodict
 
+from actinia_core.version import G_VERSION
+
 from actinia_module_plugin.model.modules import Module
 from actinia_module_plugin.model.modules import ModuleParameter
 from actinia_module_plugin.model.modules import ModuleParameterSchema
@@ -306,6 +308,7 @@ def ParseInterfaceDescription(xml_string, keys=None):
         parameters=parameters,
         returns=returns,
         **extrakwargs,
+        version=G_VERSION.get("version", "undefined"),
     )
 
     return grass_module

--- a/src/actinia_module_plugin/model/modules.py
+++ b/src/actinia_module_plugin/model/modules.py
@@ -135,6 +135,10 @@ class Module(Schema):
         "returns": ModuleReturns,
         "import_descr": ModuleImportDescription,
         "export": ModuleExportDescription,
+        "version": {
+            "type": "string",
+            "description": "Version of the module.",
+        },
     }
     example = describemodule_get_docs_example
     required = ["id", "description"]

--- a/tests/resources/actinia_modules/add_enumeration.json
+++ b/tests/resources/actinia_modules/add_enumeration.json
@@ -13,5 +13,6 @@
 		}
 	}],
 	"projects": [],
-	"returns": []
+	"returns": [],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/default_value.json
+++ b/tests/resources/actinia_modules/default_value.json
@@ -18,5 +18,6 @@
 		}
 	}],
 	"projects": [],
-	"returns": []
+	"returns": [],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/exporter.json
+++ b/tests/resources/actinia_modules/exporter.json
@@ -82,5 +82,6 @@
 			"subtype": "vector",
 			"type": "string"
 		}
-	}]
+	}],
+    "version": "8.5.0dev"
 }

--- a/tests/resources/actinia_modules/importer.json
+++ b/tests/resources/actinia_modules/importer.json
@@ -89,5 +89,6 @@
 			"type": "boolean"
 		}
 	}],
-	"returns": []
+	"returns": [],
+    "version": "8.5.0dev"
 }

--- a/tests/resources/actinia_modules/index_NDVI.json
+++ b/tests/resources/actinia_modules/index_NDVI.json
@@ -25,5 +25,6 @@
 		}
 	}],
 	"projects": [],
-	"returns": []
+	"returns": [],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/loop.json
+++ b/tests/resources/actinia_modules/loop.json
@@ -7,5 +7,6 @@
     "id": "loop",
     "parameters": [],
     "projects": [],
-    "returns": []
+    "returns": [],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/loop_simple.json
+++ b/tests/resources/actinia_modules/loop_simple.json
@@ -7,5 +7,6 @@
     "id": "loop_simple",
     "parameters": [],
     "projects": [],
-    "returns": []
+    "returns": [],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/nested_modules_test.json
+++ b/tests/resources/actinia_modules/nested_modules_test.json
@@ -27,15 +27,15 @@
 			"type": "array"
 		}
 	}, {
-		"description": "The input source that may be a landsat scene name, a sentinel2 scene name, a postGIS database string, or an URL that points to an accessible raster or vector file [generated from import_descr_source]",
-		"name": "url_to_geojson_point",
+		"description": "Expression to evaluate.  [generated from r.mapcalc_expression]",
+		"name": "B04_mosaic",
 		"optional": true,
 		"schema": {
 			"type": "string"
 		}
 	}, {
-		"description": "Expression to evaluate.  [generated from r.mapcalc_expression]",
-		"name": "B04_mosaic",
+		"description": "The input source that may be a landsat scene name, a sentinel2 scene name, a postGIS database string, or an URL that points to an accessible raster or vector file [generated from import_descr_source]",
+		"name": "url_to_geojson_point",
 		"optional": true,
 		"schema": {
 			"type": "string"
@@ -50,5 +50,6 @@
 		}
     }],
 	"projects": [],
-	"returns": []
+	"returns": [],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/nested_modules_test_with_export.json
+++ b/tests/resources/actinia_modules/nested_modules_test_with_export.json
@@ -85,5 +85,6 @@
         "type": "vector"
       }
     }
-  ]
+  ],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/point_in_polygon.json
+++ b/tests/resources/actinia_modules/point_in_polygon.json
@@ -17,5 +17,6 @@
   "projects": [
     "nc_spm_08"
   ],
-  "returns": []
+  "returns": [],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/point_in_polygon_with_export.json
+++ b/tests/resources/actinia_modules/point_in_polygon_with_export.json
@@ -27,5 +27,6 @@
         "type": "vector"
       }
     }
-  ]
+  ],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/r.slope.aspect.json
+++ b/tests/resources/actinia_modules/r.slope.aspect.json
@@ -189,5 +189,6 @@
 			"subtype": "cell",
 			"type": "string"
 		}
-	}]
+	}],
+    "version": "8.5.0dev"
 }

--- a/tests/resources/actinia_modules/slope_aspect.json
+++ b/tests/resources/actinia_modules/slope_aspect.json
@@ -29,5 +29,6 @@
 			"type": "string"
 		}
 	}],
-	"returns": []
-	}
+	"returns": [],
+    "version": "1"
+}

--- a/tests/resources/actinia_modules/slope_aspect_with_export.json
+++ b/tests/resources/actinia_modules/slope_aspect_with_export.json
@@ -43,5 +43,6 @@
 			"subtype": "GTiff",
 			"type": "raster"
 		}
-	}]
+	}],
+    "version": "1"
 }

--- a/tests/resources/actinia_modules/vector_area.json
+++ b/tests/resources/actinia_modules/vector_area.json
@@ -43,5 +43,6 @@
 		}
 	}],
 	"projects": [],
-	"returns": []
+	"returns": [],
+    "version": "1"
 }


### PR DESCRIPTION
- For actinia modules, use the version from the template
- For GRASS GIS modules, use the GRASS GIS version number (no matter if they are official ones)