### PR TITLE
Add subtype for importer

### DIFF
--- a/src/actinia_module_plugin/core/modules/actinia_common.py
+++ b/src/actinia_module_plugin/core/modules/actinia_common.py
@@ -333,6 +333,8 @@ class PlaceholderTransformer(object):
                             "import_descr_" + param,
                             pc.import_descr_dict,
                         )
+                        if temp_dict.get('schema'):
+                            temp_dict['schema']['subtype'] = "datasource"
                         self.vm_params.append(temp_dict)
 
         if "exporter" in gm:

--- a/src/actinia_module_plugin/core/modules/actinia_common.py
+++ b/src/actinia_module_plugin/core/modules/actinia_common.py
@@ -333,8 +333,8 @@ class PlaceholderTransformer(object):
                             "import_descr_" + param,
                             pc.import_descr_dict,
                         )
-                        if temp_dict.get('schema'):
-                            temp_dict['schema']['subtype'] = "datasource"
+                        if temp_dict.get("schema"):
+                            temp_dict["schema"]["subtype"] = "datasource"
                         self.vm_params.append(temp_dict)
 
         if "exporter" in gm:

--- a/tests/resources/actinia_modules/nested_modules_test.json
+++ b/tests/resources/actinia_modules/nested_modules_test.json
@@ -38,7 +38,8 @@
 		"name": "url_to_geojson_point",
 		"optional": true,
 		"schema": {
-			"type": "string"
+			"type": "string",
+			"subtype": "datasource"
 		}
 	}, {
 		"description": "Name for output slope raster map.  [generated from r.slope.aspect_slope]",

--- a/tests/resources/actinia_modules/point_in_polygon.json
+++ b/tests/resources/actinia_modules/point_in_polygon.json
@@ -10,7 +10,8 @@
       "name": "url_to_geojson_point",
       "optional": true,
       "schema": {
-        "type": "string"
+        "type": "string",
+        "subtype": "datasource"
       }
     }
   ],

--- a/tests/resources/actinia_modules/point_in_polygon_with_export.json
+++ b/tests/resources/actinia_modules/point_in_polygon_with_export.json
@@ -11,7 +11,8 @@
       "name": "url_to_geojson_point",
       "optional": true,
       "schema": {
-        "type": "string"
+        "type": "string",
+        "subtype": "datasource"
       }
     }
   ],


### PR DESCRIPTION
This PR adds `"subtype": "datasource"` to  a parameter in an actinia module for the importer.
Example of how process description is now returned:
```json
{
    "description": "The input source that may be a landsat scene name, a sentinel2 scene name, a postGIS database string, or an URL that points to an accessible raster or vector file [generated from import_descr_source]",
    "name": "url_to_geojson_point",
    "optional": true,
    "schema": {
        "subtype": "datasource",
        "type": "string"
    }
}
```

Not changed in this PR but also "datasource" as subtype is also possible for some GRASS GIS modules, e.g. for `v.import`

```json
{
  "categories": [
    "grass-module",
    "import",
    "projection",
    "vector"
  ],
  "description": "Imports vector data into a GRASS vector map using OGR library and reprojects on the fly.",
  "id": "v.import",
  "parameters": [
    {
      "description": "Name of OGR datasource to be imported. ",
      "name": "input",
      "optional": false,
      "schema": {
        "subtype": "datasource",
        "type": "string"
      }
    },
```

