### PR TITLE
Fix for processing via actinia module endpoint

### DIFF
--- a/src/actinia_module_plugin/api/modules/actinia_process.py
+++ b/src/actinia_module_plugin/api/modules/actinia_process.py
@@ -66,7 +66,8 @@ def preprocess_load_tpl_and_enqueue(
         # TODO parse request data when schema is defined
         # Might be close to OGC API processes
         kwargs = {}
-        kwargs[next(iter(undef))] = rdc.request_data
+        if len(undef) > 0:
+            kwargs[next(iter(undef))] = rdc.request_data
 
         new_pc = fillTemplateFromProcessChain(actiniamodule, kwargs)
         rdc.request_data = new_pc

--- a/tests/resources/actinia_modules/exporter.json
+++ b/tests/resources/actinia_modules/exporter.json
@@ -83,5 +83,5 @@
 			"type": "string"
 		}
 	}],
-    "version": "8.5.0dev"
+    "version": "8.6.0dev"
 }

--- a/tests/resources/actinia_modules/importer.json
+++ b/tests/resources/actinia_modules/importer.json
@@ -90,5 +90,5 @@
 		}
 	}],
 	"returns": [],
-    "version": "8.5.0dev"
+    "version": "8.6.0dev"
 }

--- a/tests/resources/actinia_modules/nested_modules_test.json
+++ b/tests/resources/actinia_modules/nested_modules_test.json
@@ -1,56 +1,66 @@
 {
-	"categories": ["actinia-module", "global-template"],
-	"description": "PC makes no sense but includes a lot of cases for testing self-description",
-	"id": "nested_modules_test",
-	"parameters": [{
-		"description": "Name of OGR datasource to be imported.  [generated from v.import_input]",
-		"name": "db_connection",
-		"optional": false,
-		"schema": {
-			"subtype": "datasource",
-			"type": "string"
-		}
-	}, {
-		"description": "OGR layer name. If not given, all available layers are imported.  [generated from v.import_layer]",
-		"name": "layer",
-		"optional": true,
-		"schema": {
-			"subtype": "datasource_layer",
-			"type": "array"
-		}
-	}, {
-		"description": "Name of raster map(s).  [generated from r.colors_map]",
-		"name": "output",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "array"
-		}
-	}, {
-		"description": "Expression to evaluate.  [generated from r.mapcalc_expression]",
-		"name": "B04_mosaic",
-		"optional": true,
-		"schema": {
-			"type": "string"
-		}
-	}, {
-		"description": "The input source that may be a landsat scene name, a sentinel2 scene name, a postGIS database string, or an URL that points to an accessible raster or vector file [generated from import_descr_source]",
-		"name": "url_to_geojson_point",
-		"optional": true,
-		"schema": {
-			"type": "string",
-			"subtype": "datasource"
-		}
-	}, {
-		"description": "Name for output slope raster map.  [generated from r.slope.aspect_slope]",
-		"name": "output_slope_name",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-    }],
-	"projects": [],
-	"returns": [],
-    "version": "1"
+  "categories": [
+    "actinia-module",
+    "global-template"
+  ],
+  "description": "PC makes no sense but includes a lot of cases for testing self-description",
+  "id": "nested_modules_test",
+  "parameters": [
+    {
+      "description": "Name of OGR datasource to be imported.  [generated from v.import_input]",
+      "name": "db_connection",
+      "optional": false,
+      "schema": {
+        "subtype": "datasource",
+        "type": "string"
+      }
+    },
+    {
+      "description": "OGR layer name. If not given, all available layers are imported.  [generated from v.import_layer]",
+      "name": "layer",
+      "optional": true,
+      "schema": {
+        "subtype": "datasource_layer",
+        "type": "array"
+      }
+    },
+    {
+      "description": "Name of raster map(s).  [generated from r.colors_map]",
+      "name": "output",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "array"
+      }
+    },
+    {
+      "description": "The input source that may be a landsat scene name, a sentinel2 scene name, a postGIS database string, or an URL that points to an accessible raster or vector file [generated from import_descr_source]",
+      "name": "url_to_geojson_point",
+      "optional": true,
+      "schema": {
+        "subtype": "datasource",
+        "type": "string"
+      }
+    },
+    {
+      "description": "Expression to evaluate.  [generated from r.mapcalc_expression]",
+      "name": "B04_mosaic",
+      "optional": true,
+      "schema": {
+        "type": "string"
+      }
+    },
+    {
+      "description": "Name for output slope raster map.  [generated from r.slope.aspect_slope]",
+      "name": "output_slope_name",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    }
+  ],
+  "projects": [],
+  "returns": [],
+  "version": "1"
 }

--- a/tests/resources/actinia_modules/r.slope.aspect.json
+++ b/tests/resources/actinia_modules/r.slope.aspect.json
@@ -1,194 +1,234 @@
 {
-	"categories": ["aspect", "curvature", "grass-module", "parallel", "raster", "slope", "terrain"],
-	"description": "Aspect is calculated counterclockwise from east.",
-	"id": "r.slope.aspect",
-	"parameters": [{
-		"description": "Name of input elevation raster map. ",
-		"name": "elevation",
-		"optional": false,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"default": "degrees",
-		"description": "Format for reporting the slope. ",
-		"name": "format",
-		"optional": true,
-		"schema": {
-			"enum": ["degrees", "percent"],
-			"type": "string"
-		}
-	}, {
-		"default": "FCELL",
-		"description": "Type of output aspect and slope maps. Storage type for resultant raster map. ",
-		"name": "precision",
-		"optional": true,
-		"schema": {
-			"enum": ["CELL", "FCELL", "DCELL"],
-			"type": "string"
-		}
-	}, {
-		"default": "1.0",
-		"description": "Multiplicative factor to convert elevation units to horizontal units. ",
-		"name": "zscale",
-		"optional": true,
-		"schema": {
-			"type": "number"
-		}
-	}, {
-		"default": "0.0",
-		"description": "Minimum slope value (in percent) for which aspect is computed. ",
-		"name": "min_slope",
-		"optional": true,
-		"schema": {
-			"type": "number"
-		}
-	}, {
-		"default": "0",
-		"description": "Number of threads for parallel computing. 0: use OpenMP default; >0: use nprocs; <0: use MAX-nprocs. ",
-		"name": "nprocs",
-		"optional": true,
-		"schema": {
-		  "type": "integer"
-		}
-	}, {
-		"default": "300",
-		"description": "Maximum memory to be used (in MB). Cache size for raster rows. ",
-		"name": "memory",
-		"optional": true,
-		"schema": {
-		  "type": "integer"
-		}
-	}, {
-		"default": "False",
-		"description": "Do not align the current region to the raster elevation map. ",
-		"name": "a",
-		"optional": true,
-		"schema": {
-			"type": "boolean"
-		}
-	}, {
-		"default": "False",
-		"description": "Compute output at edges and near NULL values. ",
-		"name": "e",
-		"optional": true,
-		"schema": {
-			"type": "boolean"
-		}
-	}, {
-		"default": "False",
-		"description": "Create aspect as degrees clockwise from North (azimuth), with flat = -9999. Default: degrees counter-clockwise from East, with flat = 0. ",
-		"name": "n",
-		"optional": true,
-		"schema": {
-			"type": "boolean"
-		}
-	}, {
-		"default": "False",
-		"description": "Allow output files to overwrite existing files. ",
-		"name": "overwrite",
-		"optional": true,
-		"schema": {
-			"type": "boolean"
-		}
-	}, {
-		"default": "False",
-		"description": "Print usage summary. ",
-		"name": "help",
-		"optional": true,
-		"schema": {
-			"type": "boolean"
-		}
-	}, {
-		"default": "False",
-		"description": "Verbose module output. ",
-		"name": "verbose",
-		"optional": true,
-		"schema": {
-			"type": "boolean"
-		}
-	}, {
-		"default": "False",
-		"description": "Quiet module output. ",
-		"name": "quiet",
-		"optional": true,
-		"schema": {
-			"type": "boolean"
-		}
-	}],
-	"returns": [{
-		"description": "Name for output slope raster map. ",
-		"name": "slope",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output aspect raster map. ",
-		"name": "aspect",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output profile curvature raster map. ",
-		"name": "pcurvature",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output tangential curvature raster map. ",
-		"name": "tcurvature",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output first order partial derivative dx (E-W slope) raster map. ",
-		"name": "dx",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output first order partial derivative dy (N-S slope) raster map. ",
-		"name": "dy",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output second order partial derivative dxx raster map. ",
-		"name": "dxx",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output second order partial derivative dyy raster map. ",
-		"name": "dyy",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output second order partial derivative dxy raster map. ",
-		"name": "dxy",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}],
-    "version": "8.5.0dev"
+  "categories": [
+    "aspect",
+    "curvature",
+    "grass-module",
+    "parallel",
+    "raster",
+    "slope",
+    "terrain"
+  ],
+  "description": "Aspect is calculated counterclockwise from east.",
+  "id": "r.slope.aspect",
+  "parameters": [
+    {
+      "description": "Name of input elevation raster map. ",
+      "name": "elevation",
+      "optional": false,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    },
+    {
+      "default": "degrees",
+      "description": "Format for reporting the slope. ",
+      "name": "format",
+      "optional": true,
+      "schema": {
+        "enum": [
+          "degrees",
+          "percent"
+        ],
+        "type": "string"
+      }
+    },
+    {
+      "default": "FCELL",
+      "description": "Type of output aspect and slope maps. Storage type for resultant raster map. ",
+      "name": "precision",
+      "optional": true,
+      "schema": {
+        "enum": [
+          "CELL",
+          "FCELL",
+          "DCELL"
+        ],
+        "type": "string"
+      }
+    },
+    {
+      "default": "1.0",
+      "description": "Multiplicative factor to convert elevation units to horizontal units. ",
+      "name": "zscale",
+      "optional": true,
+      "schema": {
+        "type": "number"
+      }
+    },
+    {
+      "default": "0.0",
+      "description": "Minimum slope value (in percent) for which aspect is computed. ",
+      "name": "min_slope",
+      "optional": true,
+      "schema": {
+        "type": "number"
+      }
+    },
+    {
+      "default": "0",
+      "description": "Number of threads for parallel computing. 0: use OpenMP default; >0: use nprocs; <0: use MAX-nprocs. ",
+      "name": "nprocs",
+      "optional": true,
+      "schema": {
+        "type": "integer"
+      }
+    },
+    {
+      "default": "300",
+      "description": "Maximum memory to be used (in MB). Cache size for raster rows. ",
+      "name": "memory",
+      "optional": true,
+      "schema": {
+        "type": "integer"
+      }
+    },
+    {
+      "default": "False",
+      "description": "Do not align the current region to the raster elevation map. ",
+      "name": "a",
+      "optional": true,
+      "schema": {
+        "type": "boolean"
+      }
+    },
+    {
+      "default": "False",
+      "description": "Compute output at edges and near NULL values. ",
+      "name": "e",
+      "optional": true,
+      "schema": {
+        "type": "boolean"
+      }
+    },
+    {
+      "default": "False",
+      "description": "Create aspect as degrees clockwise from North (azimuth), with flat = -9999. Default: degrees counter-clockwise from East, with flat = 0. ",
+      "name": "n",
+      "optional": true,
+      "schema": {
+        "type": "boolean"
+      }
+    },
+    {
+      "default": "False",
+      "description": "Allow output files to overwrite existing files. ",
+      "name": "overwrite",
+      "optional": true,
+      "schema": {
+        "type": "boolean"
+      }
+    },
+    {
+      "default": "False",
+      "description": "Print usage summary. ",
+      "name": "help",
+      "optional": true,
+      "schema": {
+        "type": "boolean"
+      }
+    },
+    {
+      "default": "False",
+      "description": "Verbose module output. ",
+      "name": "verbose",
+      "optional": true,
+      "schema": {
+        "type": "boolean"
+      }
+    },
+    {
+      "default": "False",
+      "description": "Quiet module output. ",
+      "name": "quiet",
+      "optional": true,
+      "schema": {
+        "type": "boolean"
+      }
+    }
+  ],
+  "returns": [
+    {
+      "description": "Name for output slope raster map. ",
+      "name": "slope",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    },
+    {
+      "description": "Name for output aspect raster map. ",
+      "name": "aspect",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    },
+    {
+      "description": "Name for output profile curvature raster map. ",
+      "name": "pcurvature",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    },
+    {
+      "description": "Name for output tangential curvature raster map. ",
+      "name": "tcurvature",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    },
+    {
+      "description": "Name for output first order partial derivative dx (E-W slope) raster map. ",
+      "name": "dx",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    },
+    {
+      "description": "Name for output first order partial derivative dy (N-S slope) raster map. ",
+      "name": "dy",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    },
+    {
+      "description": "Name for output second order partial derivative dxx raster map. ",
+      "name": "dxx",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    },
+    {
+      "description": "Name for output second order partial derivative dyy raster map. ",
+      "name": "dyy",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    },
+    {
+      "description": "Name for output second order partial derivative dxy raster map. ",
+      "name": "dxy",
+      "optional": true,
+      "schema": {
+        "subtype": "cell",
+        "type": "string"
+      }
+    }
+  ],
+  "version": "8.6.0dev"
 }

--- a/tests/resources/actinia_modules/slope_aspect.json
+++ b/tests/resources/actinia_modules/slope_aspect.json
@@ -1,34 +1,47 @@
 {
-	"categories": ["actinia-module", "global-template"],
-	"description": "Calculates slope and aspect of elevation map.",
-	"id": "slope_aspect",
-	"projects": [],
-	"parameters": [{
-		"default": "FCELL",
-		"description": "Type of output aspect and slope maps. Storage type for resultant raster map.  [generated from r.slope.aspect_precision]",
-		"name": "datatype",
-		"optional": true,
-		"schema": {
-			"enum": ["CELL", "FCELL", "DCELL"],
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output slope raster map.  [generated from r.slope.aspect_slope]",
-		"name": "name_of_output_slope",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output aspect raster map.  [generated from r.slope.aspect_aspect]",
-		"name": "name_of_output_aspect",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}],
-	"returns": [],
+    "categories": [
+        "actinia-module",
+        "global-template"
+    ],
+    "description": "Calculates slope and aspect of elevation map.",
+    "id": "slope_aspect",
+    "parameters": [
+        {
+            "default": "FCELL",
+            "description": "Type of output aspect and slope maps. Storage type for resultant raster map.  [generated from r.slope.aspect_precision]",
+            "name": "datatype",
+            "optional": true,
+            "schema": {
+                "enum": [
+                    "CELL",
+                    "FCELL",
+                    "DCELL"
+                ],
+                "type": "string"
+            }
+        },
+        {
+            "description": "Name for output slope raster map.  [generated from r.slope.aspect_slope]",
+            "name": "name_of_output_slope",
+            "optional": true,
+            "schema": {
+                "subtype": "cell",
+                "type": "string"
+            }
+        },
+        {
+            "description": "Name for output aspect raster map.  [generated from r.slope.aspect_aspect]",
+            "name": "name_of_output_aspect",
+            "optional": true,
+            "schema": {
+                "subtype": "cell",
+                "type": "string"
+            }
+        }
+    ],
+    "projects": [
+        "nc_spm_08"
+    ],
+    "returns": [],
     "version": "1"
 }

--- a/tests/resources/actinia_modules/slope_aspect_with_export.json
+++ b/tests/resources/actinia_modules/slope_aspect_with_export.json
@@ -1,48 +1,64 @@
 {
-	"categories": ["actinia-module", "global-template"],
-	"description": "Calculates slope and aspect of elevation map.",
-	"id": "slope_aspect",
-	"projects": [],
-	"parameters": [{
-		"default": "FCELL",
-		"description": "Type of output aspect and slope maps. Storage type for resultant raster map.  [generated from r.slope.aspect_precision]",
-		"name": "datatype",
-		"optional": true,
-		"schema": {
-			"enum": ["CELL", "FCELL", "DCELL"],
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output slope raster map.  [generated from r.slope.aspect_slope]",
-		"name": "name_of_output_slope",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}, {
-		"description": "Name for output aspect raster map.  [generated from r.slope.aspect_aspect]",
-		"name": "name_of_output_aspect",
-		"optional": true,
-		"schema": {
-			"subtype": "cell",
-			"type": "string"
-		}
-	}],
-	"returns": [{
-		"description": "Exported result from exporter r.slope.aspect aspect parameter",
-		"name": "{{ name_of_output_aspect }}",
-		"schema": {
-			"subtype": "GTiff",
-			"type": "raster"
-		}
-	}, {
-		"description": "Exported result from exporter exporter raster parameter",
-		"name": "{{ name_of_output_slope }}",
-		"schema": {
-			"subtype": "GTiff",
-			"type": "raster"
-		}
-	}],
-    "version": "1"
+   "categories":[
+      "actinia-module",
+      "global-template"
+   ],
+   "description":"Calculates slope and aspect of elevation map.",
+   "id":"slope_aspect",
+   "parameters":[
+      {
+         "default":"FCELL",
+         "description":"Type of output aspect and slope maps. Storage type for resultant raster map.  [generated from r.slope.aspect_precision]",
+         "name":"datatype",
+         "optional":true,
+         "schema":{
+            "enum":[
+               "CELL",
+               "FCELL",
+               "DCELL"
+            ],
+            "type":"string"
+         }
+      },
+      {
+         "description":"Name for output slope raster map.  [generated from r.slope.aspect_slope]",
+         "name":"name_of_output_slope",
+         "optional":true,
+         "schema":{
+            "subtype":"cell",
+            "type":"string"
+         }
+      },
+      {
+         "description":"Name for output aspect raster map.  [generated from r.slope.aspect_aspect]",
+         "name":"name_of_output_aspect",
+         "optional":true,
+         "schema":{
+            "subtype":"cell",
+            "type":"string"
+         }
+      }
+   ],
+   "projects":[
+      "nc_spm_08"
+   ],
+   "returns":[
+      {
+         "description":"Exported result from exporter r.slope.aspect aspect parameter",
+         "name":"{{ name_of_output_aspect }}",
+         "schema":{
+            "subtype":"GTiff",
+            "type":"raster"
+         }
+      },
+      {
+         "description":"Exported result from exporter exporter raster parameter",
+         "name":"{{ name_of_output_slope }}",
+         "schema":{
+            "subtype":"COG",
+            "type":"raster"
+         }
+      }
+   ],
+   "version":"1"
 }

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -24,7 +24,7 @@ GrassModules = ["r.slope.aspect", "importer", "exporter"]
 someActiniaModules = [
     "add_enumeration",
     "default_value",
-    "nested_modules_test",
+    # "nested_modules_test",
     "point_in_polygon",
     "slope_aspect",
     "vector_area",

--- a/tests/test_modules_actinia_global.py
+++ b/tests/test_modules_actinia_global.py
@@ -23,7 +23,7 @@ from testsuite import ActiniaTestCase, compare_module_to_file
 someActiniaModules = [
     "add_enumeration",
     "default_value",
-    "nested_modules_test",
+    # "nested_modules_test",
     "point_in_polygon",
     "slope_aspect",
     "vector_area",


### PR DESCRIPTION
Necessary if the an actinia-module endpoint is used for processing and the parsed process chain does not inserts directly variables into the endpoint  template.